### PR TITLE
Implement planner for managing container states

### DIFF
--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1,0 +1,48 @@
+package planner
+
+import (
+	"github.com/rmerezha/mtrpz-lab4/config"
+	"sync"
+)
+
+type ContainerState = string
+
+const (
+	StateCreated    ContainerState = "created"
+	StateRunning    ContainerState = "running"
+	StatePaused     ContainerState = "paused"
+	StateRestarting ContainerState = "restarting"
+	StateRemoving   ContainerState = "removing"
+	StateExited     ContainerState = "exited"
+	StateDead       ContainerState = "dead"
+)
+
+type ContainerStatus struct {
+	ManifestName string
+	Config       config.Container
+	State        ContainerState
+	Reason       string
+}
+
+type Planner struct {
+	mu      sync.RWMutex
+	storage map[string][]*ContainerStatus
+}
+
+func NewPlanner(manifests ...*config.Manifest) *Planner {
+	p := &Planner{
+		storage: make(map[string][]*ContainerStatus),
+	}
+
+	for _, m := range manifests {
+		for _, c := range m.Containers {
+			cs := &ContainerStatus{
+				ManifestName: m.Name,
+				Config:       c,
+				State:        StateCreated,
+			}
+			p.storage[c.Host] = append(p.storage[c.Host], cs)
+		}
+	}
+	return p
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -8,6 +8,7 @@ import (
 type ContainerState = string
 
 const (
+	StateNew        ContainerState = "new"
 	StateCreated    ContainerState = "created"
 	StateRunning    ContainerState = "running"
 	StatePaused     ContainerState = "paused"

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -63,3 +63,10 @@ func (p *Planner) UpdateState(host, containerName string, newState ContainerStat
 	}
 	return false
 }
+
+func (p *Planner) ListContainersByHost(host string) []*ContainerStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return append([]*ContainerStatus(nil), p.storage[host]...)
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -70,3 +70,17 @@ func (p *Planner) ListContainersByHost(host string) []*ContainerStatus {
 
 	return append([]*ContainerStatus(nil), p.storage[host]...)
 }
+
+func (p *Planner) AddManifest(m *config.Manifest) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, c := range m.Containers {
+		cs := &ContainerStatus{
+			ManifestName: m.Name,
+			Config:       c,
+			State:        StateCreated,
+		}
+		p.storage[c.Host] = append(p.storage[c.Host], cs)
+	}
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -21,7 +21,6 @@ type ContainerStatus struct {
 	ManifestName string
 	Config       config.Container
 	State        ContainerState
-	Reason       string
 }
 
 type Planner struct {

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -45,3 +45,21 @@ func NewPlanner(manifests ...*config.Manifest) *Planner {
 	}
 	return p
 }
+
+func (p *Planner) UpdateState(host, containerName string, newState ContainerState) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	containers, ok := p.storage[host]
+	if !ok {
+		return false
+	}
+
+	for _, cs := range containers {
+		if cs.Config.Name == containerName {
+			cs.State = newState
+			return true
+		}
+	}
+	return false
+}

--- a/planner/planner_test.go
+++ b/planner/planner_test.go
@@ -85,3 +85,22 @@ func TestListContainersByHost_Empty(t *testing.T) {
 		t.Errorf("expected 0 containers, got %d", len(list))
 	}
 }
+
+func TestAddManifest(t *testing.T) {
+	p := NewPlanner()
+
+	m := &config.Manifest{
+		Name: "monitoring",
+		Containers: []config.Container{
+			{Name: "prometheus", Host: "node1", Image: "prom/prometheus"},
+			{Name: "grafana", Host: "node1", Image: "grafana/grafana"},
+		},
+	}
+
+	p.AddManifest(m)
+
+	cs := p.ListContainersByHost("node1")
+	if len(cs) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(cs))
+	}
+}

--- a/planner/planner_test.go
+++ b/planner/planner_test.go
@@ -1,0 +1,87 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/rmerezha/mtrpz-lab4/config"
+)
+
+func setupPlanner() *Planner {
+	manifest := &config.Manifest{
+		Name: "example",
+		Containers: []config.Container{
+			{Name: "web", Host: "node1", Image: "nginx"},
+			{Name: "app", Host: "node1", Image: "myapp"},
+			{Name: "db", Host: "node2", Image: "postgres"},
+		},
+	}
+	return NewPlanner(manifest)
+}
+
+func TestUpdateState_Success(t *testing.T) {
+	p := setupPlanner()
+
+	ok := p.UpdateState("node1", "web", StateRunning)
+	if !ok {
+		t.Fatal("expected UpdateState to return true")
+	}
+
+	containers := p.ListContainersByHost("node1")
+	found := false
+	for _, c := range containers {
+		if c.Config.Name == "web" {
+			found = true
+			if c.State != StateRunning {
+				t.Errorf("expected state to be %q, got %q", StateRunning, c.State)
+			}
+		}
+	}
+	if !found {
+		t.Error("container 'web' not found on node1")
+	}
+}
+
+func TestUpdateState_FailWrongHost(t *testing.T) {
+	p := setupPlanner()
+
+	ok := p.UpdateState("node3", "web", StateRunning)
+	if ok {
+		t.Error("expected UpdateState to return false for unknown host")
+	}
+}
+
+func TestUpdateState_FailWrongContainer(t *testing.T) {
+	p := setupPlanner()
+
+	ok := p.UpdateState("node1", "unknown", StateRunning)
+	if ok {
+		t.Error("expected UpdateState to return false for unknown container")
+	}
+}
+
+func TestListContainersByHost(t *testing.T) {
+	p := setupPlanner()
+
+	list := p.ListContainersByHost("node1")
+	if len(list) != 2 {
+		t.Errorf("expected 2 containers on node1, got %d", len(list))
+	}
+
+	names := map[string]bool{}
+	for _, c := range list {
+		names[c.Config.Name] = true
+	}
+
+	if !names["web"] || !names["app"] {
+		t.Errorf("expected containers 'web' and 'app' on node1, got %+v", names)
+	}
+}
+
+func TestListContainersByHost_Empty(t *testing.T) {
+	p := setupPlanner()
+
+	list := p.ListContainersByHost("unknown-host")
+	if len(list) != 0 {
+		t.Errorf("expected 0 containers, got %d", len(list))
+	}
+}


### PR DESCRIPTION
This pull request includes:

- Functionality to track container states by host  
- In-memory storage using a map  
- Adding new manifests at runtime  
- Updating container state by name and host  
- Listing containers by host  
- Unit tests